### PR TITLE
escape post title text in twitter share button

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -28,7 +28,7 @@ layout: default
 </article>
 
 <div class="share">
-  <a href="https://twitter.com/share" class="twitter-share-button" data-text='"{{ page.title }}" by @{{ author.social.Twitter.username }}' data-size="large" data-count="none" data-dnt="true">Tweet</a>
+  <a href="https://twitter.com/share" class="twitter-share-button" data-text='"{{ page.title | escape }}" by @{{ author.social.Twitter.username }}' data-size="large" data-count="none" data-dnt="true">Tweet</a>
   <script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
 </div>
 


### PR DESCRIPTION
Posts with an apostrophe have broken `data-text` due to premature closing of the attribute. The `escape` liquid filter should do the trick here. Alternatively, you could just surround the title with single quotes, but considering you broke your convention of using double quotes for attributes, I figured you would prefer to keep the double quotes and use this escape instead.